### PR TITLE
Adds Delay to Pickpocketing

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -388,7 +388,7 @@
 						if(!(zone_selected in stealablezones))
 							to_chat(src, "<span class='warning'>What am I going to steal from there?</span>")
 							return
-						if(do_after(U, 6 SECONDS, target = V, progress = 0))
+						if(do_after(U, 2 SECONDS, target = V, progress = 0))
 							switch(U.zone_selected)
 								if("chest")
 									if (V.get_item_by_slot(SLOT_BACK_L))


### PR DESCRIPTION
Adds a two second period where both players must be standing still for a pickpocket to take place. Time is likely to change depending on tests. No progress bar or message  appears to the pickpocketed while this is in progress so it's still stealthy, now you just can't instantly pick someone's pocket.